### PR TITLE
Change loadeR dependency from suggests to depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: climate4R.UDG
 Depends:
     R(>= 3.5.0),
-    rJava
+    rJava,
+    loadeR
 Imports:
     utils,
     RCurl,
 Suggests:
-    loadeR,
     loadeR.ECOMS,
     transformeR,
     visualizeR,


### PR DESCRIPTION
If a new R session is started and climate4R.UDG is loaded but loadeR is not, the JVM is not initialized:

```
$ R
> library(climate4R.UDG)
...
> loginUDG(USER, PASSWORD)
[2021-06-29 12:53:32] Setting credentials...
[2021-06-29 12:53:32] Success!
Go to <http://www.meteo.unican.es/udg-tap/home> for details on your authorized groups and datasets
Error in jclassName(class, class.loader = class.loader) : 
  java.lang.ClassNotFoundException
```